### PR TITLE
Add AI-generated messages to weekly summaries using Claude

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -5,10 +5,10 @@ namespace FitWifFrens.Web.Background
 {
     public class AiSummaryService
     {
-        private readonly AnthropicClient _client;
+        private readonly AnthropicClient? _client;
         private readonly ILogger<AiSummaryService> _logger;
 
-        public AiSummaryService(AnthropicClient client, ILogger<AiSummaryService> logger)
+        public AiSummaryService(ILogger<AiSummaryService> logger, AnthropicClient? client = null)
         {
             _client = client;
             _logger = logger;
@@ -148,6 +148,8 @@ namespace FitWifFrens.Web.Background
 
         private async Task<string?> CallClaude(string prompt, CancellationToken cancellationToken)
         {
+            if (_client == null) return null;
+
             var parameters = new MessageParameters
             {
                 Messages = [new Message(RoleType.User, prompt)],

--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -1,0 +1,163 @@
+using Anthropic.SDK;
+using Anthropic.SDK.Messaging;
+
+namespace FitWifFrens.Web.Background
+{
+    public class AiSummaryService
+    {
+        private readonly AnthropicClient _client;
+        private readonly ILogger<AiSummaryService> _logger;
+
+        public AiSummaryService(AnthropicClient client, ILogger<AiSummaryService> logger)
+        {
+            _client = client;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Generates a short, fun intro line for the weekly weight summary.
+        /// Falls back to a default header if the AI call fails.
+        /// </summary>
+        public async Task<string> GenerateWeightSummaryIntro(
+            IEnumerable<(string Name, double WeightChange)> weekly,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var lines = weekly
+                    .Select(w => w.WeightChange < 0
+                        ? $"{w.Name}: {Math.Abs(w.WeightChange):F1} kg lost"
+                        : w.WeightChange > 0
+                            ? $"{w.Name}: {w.WeightChange:F1} kg gained"
+                            : $"{w.Name}: no change")
+                    .ToList();
+
+                var dataText = lines.Count > 0
+                    ? string.Join(", ", lines)
+                    : "no weigh-ins this week";
+
+                var prompt =
+                    $"You are a witty and encouraging fitness group coach posting a weekly weight update to a group chat. " +
+                    $"Write a single short sentence (max 15 words) as an intro to the weekly weight summary. " +
+                    $"Keep it fun, positive, and vary the style each time — sometimes motivational, sometimes playful. " +
+                    $"This week's data: {dataText}. " +
+                    $"Output only the sentence, no quotes, no extra text.";
+
+                return await CallClaude(prompt, cancellationToken) ?? "Weight Summary";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "AI weight summary intro generation failed, using default.");
+                return "Weight Summary";
+            }
+        }
+
+        /// <summary>
+        /// Generates a short, fun intro line for the weekly poll summary.
+        /// Falls back to a default header if the AI call fails.
+        /// </summary>
+        public async Task<string> GeneratePollSummaryIntro(
+            string question,
+            IEnumerable<(string Name, double AverageRating)> weekly,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var lines = weekly
+                    .Select(w => $"{w.Name}: avg {w.AverageRating:F1}/5")
+                    .ToList();
+
+                var dataText = lines.Count > 0
+                    ? string.Join(", ", lines)
+                    : "no responses this week";
+
+                var prompt =
+                    $"You are a witty and encouraging fitness group coach posting a weekly poll recap to a group chat. " +
+                    $"The poll question was: \"{question}\". " +
+                    $"Write a single short sentence (max 15 words) as an intro to the poll summary results. " +
+                    $"Keep it fun and vary the style each time. " +
+                    $"This week's ratings: {dataText}. " +
+                    $"Output only the sentence, no quotes, no extra text.";
+
+                return await CallClaude(prompt, cancellationToken) ?? $"Q: {question}";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "AI poll summary intro generation failed, using default.");
+                return $"Q: {question}";
+            }
+        }
+
+        /// <summary>
+        /// Generates a unique witty one-liner commentary per person based on their diet rating vs weight change.
+        /// Falls back to the provided default commentary if the AI call fails.
+        /// </summary>
+        public async Task<Dictionary<string, string>> GenerateCorrelationCommentaries(
+            IEnumerable<(string Name, double AvgDietRating, double WeightChange, string DefaultCommentary)> correlations,
+            CancellationToken cancellationToken)
+        {
+            var correlationList = correlations.ToList();
+            var result = correlationList.ToDictionary(c => c.Name, c => c.DefaultCommentary);
+
+            try
+            {
+                var lines = correlationList.Select(c =>
+                {
+                    var weightText = c.WeightChange < 0
+                        ? $"{Math.Abs(c.WeightChange):F1} kg lost"
+                        : c.WeightChange > 0
+                            ? $"{c.WeightChange:F1} kg gained"
+                            : "no change";
+                    return $"{c.Name}: diet rating {c.AvgDietRating:F1}/5, {weightText}";
+                });
+
+                var dataText = string.Join("\n", lines);
+
+                var prompt =
+                    $"You are a witty fitness group coach writing brief comments for a weekly group stats message. " +
+                    $"For each person below, write one short witty sentence (max 12 words) commenting on how their diet rating compared to their actual weight change. " +
+                    $"Be funny, varied in style, and mildly sarcastic where appropriate — but always keep it friendly. " +
+                    $"Return exactly one line per person in this format: NAME: comment\n\n" +
+                    $"{dataText}\n\n" +
+                    $"Output only the NAME: comment lines, nothing else.";
+
+                var response = await CallClaude(prompt, cancellationToken);
+                if (response == null) return result;
+
+                foreach (var line in response.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    var colonIndex = line.IndexOf(':');
+                    if (colonIndex <= 0) continue;
+
+                    var name = line[..colonIndex].Trim();
+                    var comment = line[(colonIndex + 1)..].Trim();
+
+                    if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(comment) && result.ContainsKey(name))
+                    {
+                        result[name] = comment;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "AI correlation commentary generation failed, using defaults.");
+            }
+
+            return result;
+        }
+
+        private async Task<string?> CallClaude(string prompt, CancellationToken cancellationToken)
+        {
+            var parameters = new MessageParameters
+            {
+                Messages = [new Message(RoleType.User, prompt)],
+                MaxTokens = 512,
+                Model = AnthropicModels.Claude3Haiku,
+                Temperature = 1.0m,
+            };
+
+            var response = await _client.Messages.GetClaudeMessageAsync(parameters, cancellationToken);
+            return response.Content.OfType<TextContent>().FirstOrDefault()?.Text?.Trim();
+        }
+    }
+}

--- a/FitWifFrens.Web/Background/TelegramCorrelationSummaryService.cs
+++ b/FitWifFrens.Web/Background/TelegramCorrelationSummaryService.cs
@@ -11,6 +11,7 @@ namespace FitWifFrens.Web.Background
 
         private readonly DataContext _dataContext;
         private readonly NotificationService _notificationService;
+        private readonly AiSummaryService _aiSummaryService;
         private readonly TimeProvider _timeProvider;
         private readonly TelemetryClient _telemetryClient;
         private readonly ILogger<TelegramCorrelationSummaryService> _logger;
@@ -18,12 +19,14 @@ namespace FitWifFrens.Web.Background
         public TelegramCorrelationSummaryService(
             DataContext dataContext,
             NotificationService notificationService,
+            AiSummaryService aiSummaryService,
             TimeProvider timeProvider,
             TelemetryClient telemetryClient,
             ILogger<TelegramCorrelationSummaryService> logger)
         {
             _dataContext = dataContext;
             _notificationService = notificationService;
+            _aiSummaryService = aiSummaryService;
             _timeProvider = timeProvider;
             _telemetryClient = telemetryClient;
             _logger = logger;
@@ -71,7 +74,12 @@ namespace FitWifFrens.Web.Background
                     return;
                 }
 
-                var message = BuildSummaryMessage(correlations);
+                var commentaryInputs = correlations.Select(c =>
+                    (c.Name, c.AvgDietRating, c.WeightChange, GetFallbackCommentary(c.AvgDietRating, c.WeightChange)));
+
+                var commentaries = await _aiSummaryService.GenerateCorrelationCommentaries(commentaryInputs, cancellationToken);
+
+                var message = BuildSummaryMessage(correlations, commentaries);
                 await _notificationService.Notify(message);
 
                 using var chartStream = BuildCorrelationChart(correlations);
@@ -85,7 +93,7 @@ namespace FitWifFrens.Web.Background
             }
         }
 
-        private static string BuildSummaryMessage(IReadOnlyList<UserCorrelation> correlations)
+        private static string BuildSummaryMessage(IReadOnlyList<UserCorrelation> correlations, Dictionary<string, string> commentaries)
         {
             var builder = new StringBuilder();
 
@@ -100,15 +108,17 @@ namespace FitWifFrens.Web.Background
                         ? $"{c.WeightChange:F1} kg gained"
                         : "no change";
 
+                var commentary = commentaries.TryGetValue(c.Name, out var aiComment) ? aiComment : GetFallbackCommentary(c.AvgDietRating, c.WeightChange);
+
                 builder.AppendLine($"- {c.Name}: avg diet rating {c.AvgDietRating:F1}/5, {weightText}");
-                builder.AppendLine($"  {GetCommentary(c.AvgDietRating, c.WeightChange)}");
+                builder.AppendLine($"  {commentary}");
             }
 
             var message = builder.ToString().TrimEnd();
             return message.Length <= 4000 ? message : message[..4000];
         }
 
-        private static string GetCommentary(double avgRating, double weightChange)
+        private static string GetFallbackCommentary(double avgRating, double weightChange)
         {
             // Above 3 = expects weight loss, below 3 = expects weight gain, 3 = flat
             var expectsLoss = avgRating > 3.0;

--- a/FitWifFrens.Web/Background/TelegramPollSummaryService.cs
+++ b/FitWifFrens.Web/Background/TelegramPollSummaryService.cs
@@ -11,6 +11,7 @@ namespace FitWifFrens.Web.Background
 
         private readonly DataContext _dataContext;
         private readonly NotificationService _notificationService;
+        private readonly AiSummaryService _aiSummaryService;
         private readonly TimeProvider _timeProvider;
         private readonly TelemetryClient _telemetryClient;
         private readonly ILogger<TelegramPollSummaryService> _logger;
@@ -18,12 +19,14 @@ namespace FitWifFrens.Web.Background
         public TelegramPollSummaryService(
             DataContext dataContext,
             NotificationService notificationService,
+            AiSummaryService aiSummaryService,
             TimeProvider timeProvider,
             TelemetryClient telemetryClient,
             ILogger<TelegramPollSummaryService> logger)
         {
             _dataContext = dataContext;
             _notificationService = notificationService;
+            _aiSummaryService = aiSummaryService;
             _timeProvider = timeProvider;
             _telemetryClient = telemetryClient;
             _logger = logger;
@@ -81,7 +84,13 @@ namespace FitWifFrens.Web.Background
                     .OrderBy(q => q)
                     .FirstOrDefaultAsync(cancellationToken);
 
-                var message = BuildSummaryMessage(weekly, monthly, allTime, question);
+                var resolvedQuestion = question ?? "How do you rate your diet?";
+                var introLine = await _aiSummaryService.GeneratePollSummaryIntro(
+                    resolvedQuestion,
+                    weekly.Select(a => (ResolveName(a), a.AverageValue)),
+                    cancellationToken);
+
+                var message = BuildSummaryMessage(introLine, weekly, monthly, allTime);
                 await _notificationService.Notify(message);
             }
             catch (Exception exception)
@@ -93,14 +102,14 @@ namespace FitWifFrens.Web.Background
         }
 
         private static string BuildSummaryMessage(
+            string introLine,
             IReadOnlyCollection<PollAggregate> weekly,
             IReadOnlyCollection<PollAggregate> monthly,
-            IReadOnlyCollection<PollAggregate> allTime,
-            string? question)
+            IReadOnlyCollection<PollAggregate> allTime)
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine($"Q: {question ?? "How do you rate your diet?"}");
+            builder.AppendLine(introLine);
             builder.AppendLine();
 
             builder.AppendLine("Past 7 days:");

--- a/FitWifFrens.Web/Background/TelegramWeightSummaryService.cs
+++ b/FitWifFrens.Web/Background/TelegramWeightSummaryService.cs
@@ -13,6 +13,7 @@ namespace FitWifFrens.Web.Background
 
         private readonly DataContext _dataContext;
         private readonly NotificationService _notificationService;
+        private readonly AiSummaryService _aiSummaryService;
         private readonly TimeProvider _timeProvider;
         private readonly TelemetryClient _telemetryClient;
         private readonly ILogger<TelegramWeightSummaryService> _logger;
@@ -20,12 +21,14 @@ namespace FitWifFrens.Web.Background
         public TelegramWeightSummaryService(
             DataContext dataContext,
             NotificationService notificationService,
+            AiSummaryService aiSummaryService,
             TimeProvider timeProvider,
             TelemetryClient telemetryClient,
             ILogger<TelegramWeightSummaryService> logger)
         {
             _dataContext = dataContext;
             _notificationService = notificationService;
+            _aiSummaryService = aiSummaryService;
             _timeProvider = timeProvider;
             _telemetryClient = telemetryClient;
             _logger = logger;
@@ -90,7 +93,11 @@ namespace FitWifFrens.Web.Background
                         g.Last().Value - g.First().Value))
                     .ToList();
 
-                var message = BuildSummaryMessage(weekly, monthly, allTime);
+                var introLine = await _aiSummaryService.GenerateWeightSummaryIntro(
+                    weekly.Select(a => (ResolveName(a), a.WeightChange)),
+                    cancellationToken);
+
+                var message = BuildSummaryMessage(introLine, weekly, monthly, allTime);
                 await _notificationService.Notify(message);
 
                 var threeMonthStartTime = now.AddMonths(-3);
@@ -131,13 +138,14 @@ namespace FitWifFrens.Web.Background
         }
 
         private static string BuildSummaryMessage(
+            string introLine,
             IReadOnlyCollection<WeightAggregate> weekly,
             IReadOnlyCollection<WeightAggregate> monthly,
             IReadOnlyCollection<WeightAggregate> allTime)
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine("Weight Summary");
+            builder.AppendLine(introLine);
             builder.AppendLine();
 
             builder.AppendLine("Past 7 days:");

--- a/FitWifFrens.Web/FitWifFrens.Web.csproj
+++ b/FitWifFrens.Web/FitWifFrens.Web.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Nethereum.Metamask.Blazor" Version="4.20.*" />
     <PackageReference Include="Nethereum.UI" Version="4.20.*" />
     <PackageReference Include="Nethereum.Web3" Version="4.20.*" />
+    <PackageReference Include="Anthropic.SDK" Version="3.*" />
     <PackageReference Include="Polly" Version="8.4.*" />
     <PackageReference Include="ScottPlot" Version="5.1.*" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.*" />

--- a/FitWifFrens.Web/Program.cs
+++ b/FitWifFrens.Web/Program.cs
@@ -165,7 +165,11 @@ namespace FitWifFrens.Web
             builder.Services.AddSingleton<TelegramPollResponseStore>();
             builder.Services.AddSingleton<TelegramPollService>();
 
-            builder.Services.AddSingleton(new AnthropicClient(builder.Configuration.GetValue<string>("Services:Anthropic:ApiKey")!));
+            var anthropicApiKey = builder.Configuration.GetValue<string>("Services:Anthropic:ApiKey");
+            if (!string.IsNullOrWhiteSpace(anthropicApiKey))
+            {
+                builder.Services.AddSingleton(new AnthropicClient(anthropicApiKey));
+            }
             builder.Services.AddScoped<AiSummaryService>();
 
             builder.Services.AddScoped<MicrosoftService>();

--- a/FitWifFrens.Web/Program.cs
+++ b/FitWifFrens.Web/Program.cs
@@ -1,3 +1,4 @@
+using Anthropic.SDK;
 using AspNet.Security.OAuth.Strava;
 using AspNet.Security.OAuth.Withings;
 using FitWifFrens.Data;
@@ -164,11 +165,15 @@ namespace FitWifFrens.Web
             builder.Services.AddSingleton<TelegramPollResponseStore>();
             builder.Services.AddSingleton<TelegramPollService>();
 
+            builder.Services.AddSingleton(new AnthropicClient(builder.Configuration.GetValue<string>("Services:Anthropic:ApiKey")!));
+            builder.Services.AddScoped<AiSummaryService>();
+
             builder.Services.AddScoped<MicrosoftService>();
             builder.Services.AddScoped<StravaService>();
             builder.Services.AddScoped<WithingsService>();
             builder.Services.AddScoped<TelegramPollJobService>();
             builder.Services.AddScoped<TelegramPollSummaryService>();
+            builder.Services.AddScoped<TelegramWeightSummaryService>();
             builder.Services.AddScoped<TelegramCorrelationSummaryService>();
             builder.Services.AddScoped<CommitmentPeriodService>();
 


### PR DESCRIPTION
Replaces hard-coded header text and commentary in the weekly weight,
poll, and correlation summaries with AI-generated messages via the
Anthropic SDK. Each run now produces unique, varied text. Falls back
to the original hard-coded strings if the API call fails.

- Add Anthropic.SDK NuGet package
- New AiSummaryService with three methods:
  - GenerateWeightSummaryIntro: fun one-liner intro for weight summary
  - GeneratePollSummaryIntro: fun one-liner intro for poll summary
  - GenerateCorrelationCommentaries: per-person witty commentary (single batched API call)
- Inject AiSummaryService into all three summary services
- Register AnthropicClient and AiSummaryService in DI (Program.cs)
- Register TelegramWeightSummaryService in DI (was missing)
- API key configured via Services:Anthropic:ApiKey in app config

https://claude.ai/code/session_01QNnkhhnwUEQ3T8T16Tpzgb