### PR TITLE
AI-generated messages for weekly weight, poll and correlation summaries

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -154,11 +154,11 @@ namespace FitWifFrens.Web.Background
             {
                 Messages = [new Message(RoleType.User, prompt)],
                 MaxTokens = 512,
-                Model = AnthropicModels.Claude3Haiku,
+                Model = "claude-3-haiku-20240307",
                 Temperature = 1.0m,
             };
 
-            var response = await _client.Messages.GetClaudeMessageAsync(parameters, cancellationToken);
+            var response = await _client.Messages.GetClaudeMessageAsync(parameters);
             return response.Content.OfType<TextContent>().FirstOrDefault()?.Text?.Trim();
         }
     }


### PR DESCRIPTION
## Summary

- Adds `Anthropic.SDK` NuGet package and a new `AiSummaryService` that wraps the Claude API
- Weekly weight and poll summaries now open with a short AI-generated intro line instead of the static `"Weight Summary"` / `"Q: ..."` headers
- Correlation summary replaces the 9 fixed `GetCommentary()` strings with unique per-person AI-generated witty one-liners (batched into a single API call)
- All AI calls fall back gracefully to the original hardcoded text if the call fails
- If `Services:Anthropic:ApiKey` is not configured, `AnthropicClient` is never registered and the service skips all AI calls — the app works fully without an API key
- Also registers `TelegramWeightSummaryService` in DI (was previously missing)

## Configuration

Add to app secrets / environment to enable AI messages:
```
Services:Anthropic:ApiKey = sk-ant-...
```

## Test plan

- [ ] Build succeeds
- [ ] App starts without `Services:Anthropic:ApiKey` configured — summaries send with hardcoded fallback text
- [ ] App starts with a valid API key — summaries send with AI-generated text
- [ ] Simulate an API failure (e.g. bad key) — summaries still send using fallback text, warning logged