### PR TITLE
Fix AI summary service DI and improve error logging

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -8,10 +8,15 @@ namespace FitWifFrens.Web.Background
         private readonly AnthropicClient? _client;
         private readonly ILogger<AiSummaryService> _logger;
 
-        public AiSummaryService(ILogger<AiSummaryService> logger, AnthropicClient? client = null)
+        public AiSummaryService(AnthropicClient? client, ILogger<AiSummaryService> logger)
         {
             _client = client;
             _logger = logger;
+
+            if (_client == null)
+            {
+                logger.LogInformation("AiSummaryService: no Anthropic API key configured, AI messages disabled.");
+            }
         }
 
         /// <summary>
@@ -47,7 +52,7 @@ namespace FitWifFrens.Web.Background
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "AI weight summary intro generation failed, using default.");
+                _logger.LogError(ex, "AI weight summary intro generation failed, using default. Error: {Message}", ex.Message);
                 return "Weight Summary";
             }
         }
@@ -83,7 +88,7 @@ namespace FitWifFrens.Web.Background
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "AI poll summary intro generation failed, using default.");
+                _logger.LogError(ex, "AI poll summary intro generation failed, using default. Error: {Message}", ex.Message);
                 return $"Q: {question}";
             }
         }
@@ -140,7 +145,7 @@ namespace FitWifFrens.Web.Background
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "AI correlation commentary generation failed, using defaults.");
+                _logger.LogError(ex, "AI correlation commentary generation failed, using defaults. Error: {Message}", ex.Message);
             }
 
             return result;

--- a/FitWifFrens.Web/Program.cs
+++ b/FitWifFrens.Web/Program.cs
@@ -166,10 +166,8 @@ namespace FitWifFrens.Web
             builder.Services.AddSingleton<TelegramPollService>();
 
             var anthropicApiKey = builder.Configuration.GetValue<string>("Services:Anthropic:ApiKey");
-            if (!string.IsNullOrWhiteSpace(anthropicApiKey))
-            {
-                builder.Services.AddSingleton(new AnthropicClient(anthropicApiKey));
-            }
+            builder.Services.AddSingleton<AnthropicClient?>(_ =>
+                string.IsNullOrWhiteSpace(anthropicApiKey) ? null : new AnthropicClient(anthropicApiKey));
             builder.Services.AddScoped<AiSummaryService>();
 
             builder.Services.AddScoped<MicrosoftService>();


### PR DESCRIPTION
## Summary

- Fixes a DI registration bug where `AnthropicClient?` was registered conditionally, causing .NET DI to throw (rather than use the `null` default) when no API key was configured — silently falling back to hardcoded text
- `AnthropicClient?` is now always registered explicitly: a real client when a key is present, `null` when not
- `AiSummaryService` constructor takes `AnthropicClient?` as a proper required parameter instead of an optional one
- Logs an info message at startup when no API key is configured
- Promoted API failure catch blocks from `LogWarning` to `LogError` so failures are clearly visible in Application Insights

## Test plan

- [ ] Build succeeds
- [ ] App starts with no `Services:Anthropic:ApiKey` — info log confirms AI disabled, summaries send with hardcoded fallback text
- [ ] App starts with a valid API key — summaries send with AI-generated text
- [ ] App starts with an invalid API key — `LogError` entries appear in Application Insights with the exact error message