### PR TITLE
Fix AI summary service - add Stream=false and debug logging

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -155,16 +155,30 @@ namespace FitWifFrens.Web.Background
         {
             if (_client == null) return null;
 
+            _logger.LogInformation("AiSummaryService: calling Claude API.");
+
             var parameters = new MessageParameters
             {
                 Messages = [new Message(RoleType.User, prompt)],
                 MaxTokens = 512,
                 Model = "claude-3-haiku-20240307",
-                Temperature = 1.0m,
+                Stream = false,
+                Temperature = 1m,
             };
 
             var response = await _client.Messages.GetClaudeMessageAsync(parameters);
-            return response.Content.OfType<TextContent>().FirstOrDefault()?.Text?.Trim();
+
+            _logger.LogInformation("AiSummaryService: Claude API responded. StopReason={StopReason}, ContentCount={Count}",
+                response.StopReason, response.Content?.Count ?? 0);
+
+            var text = response.Content?.OfType<TextContent>().FirstOrDefault()?.Text?.Trim();
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                _logger.LogWarning("AiSummaryService: response contained no text content.");
+            }
+
+            return text;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Stream = false` to `MessageParameters` — without this, Anthropic.SDK v3 may default to streaming mode causing `GetClaudeMessageAsync` to silently fail to parse the response
- Fixes DI registration so `AnthropicClient?` is always explicitly registered (either as a real client or null), removing reliance on unreliable optional constructor parameter injection
- Improves error logging from `LogWarning` to `LogError` so API failures are visible in Application Insights
- Adds detailed info logging around each API call so the flow can be traced in logs

## Test plan

- [ ] Build succeeds
- [ ] App starts — Application Insights shows `"AiSummaryService: no Anthropic API key configured"` when key is absent
- [ ] With a valid API key — Application Insights shows `"calling Claude API"` and `"Claude API responded"`, summaries contain AI-generated text
- [ ] With an invalid key — `LogError` entry appears with the exact error message