### PR TITLE
Add @FitWifFrensBot mention reply feature

### DIFF
--- a/FitWifFrens.Web/Program.cs
+++ b/FitWifFrens.Web/Program.cs
@@ -161,6 +161,7 @@ namespace FitWifFrens.Web
                 Token = builder.Configuration.GetValue<string>("Services:Telegram:Token")!,
                 ChatId = builder.Configuration.GetValue<string>("Services:Telegram:ChatId")!,
                 WebhookSecretToken = builder.Configuration.GetValue<string>("Services:Telegram:WebhookSecretToken"),
+                BotUsername = builder.Configuration.GetValue<string>("Services:Telegram:BotUsername"),
             });
             builder.Services.AddScoped<NotificationService>();
             builder.Services.AddSingleton<TelegramPollResponseStore>();


### PR DESCRIPTION
## Summary

- Anyone in the group chat can now @mention the bot and receive a contextually-aware AI reply
- The reply is generated using the last 50 chat messages (from the database) and the past 4-week fitness summary for all Telegram-linked users — similar context to the `/roast` prompt
- Bot mention detection is entity-based (Telegram's `mention` entity type), so it only triggers on real @mentions, not just text containing the bot name
- A new `Services:Telegram:BotUsername` config key controls which username triggers replies (feature is disabled if not set)

## Changes

- **`NotificationServiceConfiguration`** — added `BotUsername` property
- **`Program.cs`** — wired `Services:Telegram:BotUsername` into the config object
- **`AiSummaryService`** — added `GenerateBotMentionReply` method; also added optional `maxTokens` param to `CallClaude`
- **`TelegramBotService`** — added `IsBotMentioned` helper, `HandleBotMentionAsync` handler, and mention detection at the end of `TryProcessMessageCommandAsync` (after all slash commands, so `/roast` etc. still take priority)

## Configuration

Add to user secrets or `appsettings.json`:

```json
"Services": {
  "Telegram": {
    "BotUsername": "FitWifFrensBot"
  }
}
```

## Test plan

- [ ] Set `Services:Telegram:BotUsername` in secrets
- [ ] Send a plain message mentioning `@FitWifFrensBot` in the group — bot should reply
- [ ] Verify the reply references group fitness data
- [ ] Send `/roast@FitWifFrensBot` — should still be handled as a roast, not a mention reply
- [ ] Leave `BotUsername` unset — bot should not reply to mentions

https://claude.ai/code/session_01B9zfGxUD8vDXkUr9fNnstP