### PR TITLE
Add @FitWifFrensBot mention reply feature

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -383,7 +383,9 @@ namespace FitWifFrens.Web.Background
             try
             {
                 var messageLines = recentMessages
-                    .Select(m => $"[{m.Timestamp:HH:mm}] {m.DisplayName}: {m.Text}")
+                    .Select(m => m.DisplayName == "Bot"
+                        ? $"[{m.Timestamp:HH:mm}] [You previously replied]: {m.Text}"
+                        : $"[{m.Timestamp:HH:mm}] {m.DisplayName}: {m.Text}")
                     .ToList();
 
                 var chatContext = messageLines.Count > 0
@@ -395,7 +397,8 @@ namespace FitWifFrens.Web.Background
                     $"A group member named {senderName} just mentioned you with this message: \"{userMessage}\"\n\n" +
                     $"Respond directly and conversationally. Be helpful, funny, and aware of the group's fitness progress. " +
                     Tone("Keep it punchy and entertaining — you know everyone's stats and aren't afraid to call people out gently. ", soulPrompt) +
-                    $"Keep your reply under 150 words.\n\n" +
+                    $"Keep your reply under 150 words. " +
+                    $"Do NOT repeat or rephrase anything you have already said in this conversation — vary your angle, tone, or focus each time.\n\n" +
                     chatContext +
                     $"Current group fitness summary:\n{groupFitnessSummary}\n" +
                     FormatFactsForPrompt(allUserFacts) +


### PR DESCRIPTION
## Summary

- Anyone in the group chat can now @mention the bot and receive a contextually-aware AI reply
- The reply is generated using the last 50 chat messages and the past 4-week fitness summary for all Telegram-linked users — similar context to the `/roast` prompt
- Bot messages in the chat history are labelled as `[You previously replied]` so Claude knows its own words and doesn't repeat them
- Bot mention detection is entity-based (Telegram's `mention` entity type), so it only triggers on real @mentions
- A new `Services:Telegram:BotUsername` config key controls which username triggers replies (feature is disabled if not set)

## Changes

- **`NotificationServiceConfiguration`** — added `BotUsername` property
- **`Program.cs`** — wired `Services:Telegram:BotUsername` into the config object
- **`AiSummaryService`** — added `GenerateBotMentionReply` with recent message context and no-repeat instruction; added optional `maxTokens` param to `CallClaude`
- **`TelegramBotService`** — added `IsBotMentioned` helper, `HandleBotMentionAsync` handler, and mention detection at the end of `TryProcessMessageCommandAsync` (after all slash commands, so `/roast` etc. still take priority)

## Configuration

Add to user secrets or `appsettings.json`:

```json
"Services": {
  "Telegram": {
    "BotUsername": "FitWifFrensBot"
  }
}
```

## Test plan

- [ ] Set `Services:Telegram:BotUsername` in secrets
- [ ] Send a plain message mentioning `@FitWifFrensBot` in the group — bot should reply
- [ ] Verify the reply references group fitness data
- [ ] Mention the bot multiple times — replies should vary and not repeat previous responses
- [ ] Send `/roast@FitWifFrensBot` — should still be handled as a roast, not a mention reply
- [ ] Leave `BotUsername` unset — bot should not reply to mentions

https://claude.ai/code/session_01B9zfGxUD8vDXkUr9fNnstP