### PR TITLE
Bot mention reliability fixes + Hangfire memory extraction

### DIFF
--- a/FitWifFrens.Web/Background/JobService.cs
+++ b/FitWifFrens.Web/Background/JobService.cs
@@ -26,6 +26,7 @@ namespace FitWifFrens.Web.Background
             _recurringJobManager.AddOrUpdate<StravaService>(nameof(StravaService) + nameof(StravaService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<WithingsService>(nameof(WithingsService) + nameof(WithingsService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.PullUpdates), s => s.PullUpdates(cancellationToken), Cron.Never);
+            _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.ExtractDefaultChatMemoriesAsync), s => s.ExtractDefaultChatMemoriesAsync(CancellationToken.None), Cron.Never);
 
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.CreateCommitmentPeriods), s => s.CreateCommitmentPeriods(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.UpdateCommitmentPeriodUserGoals), s => s.UpdateCommitmentPeriodUserGoals(cancellationToken), Cron.Never);
@@ -39,6 +40,7 @@ namespace FitWifFrens.Web.Background
             _recurringJobManager.AddOrUpdate<StravaService>(nameof(StravaService) + nameof(StravaService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Hourly());
             _recurringJobManager.AddOrUpdate<WithingsService>(nameof(WithingsService) + nameof(WithingsService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Hourly());
             _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.PullUpdates), s => s.PullUpdates(cancellationToken), Cron.MinuteInterval(5));
+            _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.ExtractDefaultChatMemoriesAsync), s => s.ExtractDefaultChatMemoriesAsync(CancellationToken.None), Cron.Never);
 
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.CreateCommitmentPeriods), s => s.CreateCommitmentPeriods(cancellationToken), Cron.Hourly(5));
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.UpdateCommitmentPeriodUserGoals), s => s.UpdateCommitmentPeriodUserGoals(cancellationToken), Cron.Hourly(10));

--- a/FitWifFrens.Web/Background/JobService.cs
+++ b/FitWifFrens.Web/Background/JobService.cs
@@ -26,7 +26,6 @@ namespace FitWifFrens.Web.Background
             _recurringJobManager.AddOrUpdate<StravaService>(nameof(StravaService) + nameof(StravaService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<WithingsService>(nameof(WithingsService) + nameof(WithingsService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.PullUpdates), s => s.PullUpdates(cancellationToken), Cron.Never);
-            _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.ExtractDefaultChatMemoriesAsync), s => s.ExtractDefaultChatMemoriesAsync(CancellationToken.None), Cron.Never);
 
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.CreateCommitmentPeriods), s => s.CreateCommitmentPeriods(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.UpdateCommitmentPeriodUserGoals), s => s.UpdateCommitmentPeriodUserGoals(cancellationToken), Cron.Never);
@@ -40,7 +39,6 @@ namespace FitWifFrens.Web.Background
             _recurringJobManager.AddOrUpdate<StravaService>(nameof(StravaService) + nameof(StravaService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Hourly());
             _recurringJobManager.AddOrUpdate<WithingsService>(nameof(WithingsService) + nameof(WithingsService.UpdateProviderMetricValues), s => s.UpdateProviderMetricValues(cancellationToken), Cron.Hourly());
             _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.PullUpdates), s => s.PullUpdates(cancellationToken), Cron.MinuteInterval(5));
-            _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.ExtractDefaultChatMemoriesAsync), s => s.ExtractDefaultChatMemoriesAsync(CancellationToken.None), Cron.Never);
 
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.CreateCommitmentPeriods), s => s.CreateCommitmentPeriods(cancellationToken), Cron.Hourly(5));
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.UpdateCommitmentPeriodUserGoals), s => s.UpdateCommitmentPeriodUserGoals(cancellationToken), Cron.Hourly(10));
@@ -91,6 +89,8 @@ namespace FitWifFrens.Web.Background
                 {
                     TimeZone = TimeZoneInfo.Utc
                 });
+
+            _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.ExtractDefaultChatMemoriesAsync), s => s.ExtractDefaultChatMemoriesAsync(CancellationToken.None), Cron.Never);
 
             _backgroundJobClient.Enqueue<TelegramBotService>(s => s.RegisterBotCommandsAsync(CancellationToken.None));
 

--- a/FitWifFrens.Web/Telegram/TelegramBotService.cs
+++ b/FitWifFrens.Web/Telegram/TelegramBotService.cs
@@ -1,5 +1,6 @@
 using FitWifFrens.Data;
 using FitWifFrens.Web.Background;
+using Hangfire;
 using Microsoft.ApplicationInsights;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Concurrent;
@@ -22,6 +23,7 @@ namespace FitWifFrens.Web.Telegram
         private readonly NotificationServiceConfiguration _notificationServiceConfiguration;
         private readonly TelegramPollResponseStore _responseStore;
         private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly IBackgroundJobClient _backgroundJobClient;
         private readonly HttpClient _httpClient;
         private readonly TelemetryClient _telemetryClient;
         private readonly ILogger<TelegramBotService> _logger;
@@ -33,6 +35,7 @@ namespace FitWifFrens.Web.Telegram
             NotificationServiceConfiguration notificationServiceConfiguration,
             TelegramPollResponseStore responseStore,
             IServiceScopeFactory serviceScopeFactory,
+            IBackgroundJobClient backgroundJobClient,
             IHttpClientFactory httpClientFactory,
             TelemetryClient telemetryClient,
             ILogger<TelegramBotService> logger)
@@ -41,6 +44,7 @@ namespace FitWifFrens.Web.Telegram
             _notificationServiceConfiguration = notificationServiceConfiguration;
             _responseStore = responseStore;
             _serviceScopeFactory = serviceScopeFactory;
+            _backgroundJobClient = backgroundJobClient;
             _httpClient = httpClientFactory.CreateClient();
             _telemetryClient = telemetryClient;
             _logger = logger;
@@ -1274,7 +1278,7 @@ namespace FitWifFrens.Web.Telegram
 
                 if (_backgroundConfiguration.EnableMemoryExtraction && messageCount % 100 == 0)
                 {
-                    _ = ExtractMemoriesAsync(chatId, cancellationToken);
+                    _backgroundJobClient.Enqueue<TelegramBotService>(s => s.ExtractMemoriesAsync(chatId, CancellationToken.None));
                 }
 
                 // Prune old messages beyond 200
@@ -1316,7 +1320,7 @@ namespace FitWifFrens.Web.Telegram
             }
         }
 
-        private async Task ExtractMemoriesAsync(string chatId, CancellationToken cancellationToken)
+        public async Task ExtractMemoriesAsync(string chatId, CancellationToken cancellationToken)
         {
             try
             {

--- a/FitWifFrens.Web/Telegram/TelegramBotService.cs
+++ b/FitWifFrens.Web/Telegram/TelegramBotService.cs
@@ -1320,6 +1320,9 @@ namespace FitWifFrens.Web.Telegram
             }
         }
 
+        public Task ExtractDefaultChatMemoriesAsync(CancellationToken cancellationToken)
+            => ExtractMemoriesAsync(_notificationServiceConfiguration.ChatId, cancellationToken);
+
         public async Task ExtractMemoriesAsync(string chatId, CancellationToken cancellationToken)
         {
             try


### PR DESCRIPTION
## Summary

- Replace fire-and-forget `ExtractMemoriesAsync` with a Hangfire job — visible in the dashboard and manually triggerable
- Await `SaveBotMessageAsync` so bot replies are always committed before the next context query
- Vary bot mention reply length based on context instead of a fixed 150-word cap
- Fix CS8143 build error — EF Core can't project to tuple literals in expression trees

## Changes

- **`TelegramBotService`** — inject `IBackgroundJobClient`, enqueue `ExtractMemoriesAsync` via Hangfire, make it `public` so Hangfire can call it
- **`TelegramBotService`** — await `SaveBotMessageAsync` in `SendReplyAsync`
- **`TelegramBotService`** — fix tuple literal in EF Core `Select` expression (use anonymous type then project after `ToListAsync`)
- **`AiSummaryService`** — replace hard 150-word cap with context-aware length guidance

## Test plan

- [ ] Mention `@FitWifFrensBot` — bot replies should vary in length depending on the message
- [ ] Check the Hangfire dashboard — `ExtractMemoriesAsync` jobs should appear after every 100th message
- [ ] Manually trigger `ExtractMemoriesAsync` from the Hangfire dashboard
- [ ] Project builds without errors

https://claude.ai/code/session_01B9zfGxUD8vDXkUr9fNnstP