### PR TITLE
Increase memory extraction token limit + Hangfire manual trigger

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -580,7 +580,7 @@ namespace FitWifFrens.Web.Background
                     "Recent messages:\n" + string.Join("\n", messageLines) + "\n\n" +
                     "Output only the updated summary, nothing else.";
 
-                return await CallClaude(prompt, cancellationToken, soulPrompt);
+                return await CallClaude(prompt, cancellationToken, soulPrompt, maxTokens: 4096);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

- Increase `ExtractMemories` output from 512 to 4096 tokens so memory summaries are no longer truncated
- Register `ExtractDefaultChatMemoriesAsync` as a `Cron.Never` Hangfire job so it can be manually triggered from the dashboard UI
- Add `ExtractDefaultChatMemoriesAsync` wrapper method on `TelegramBotService` using the configured default `ChatId`

## Changes

- **`AiSummaryService`** — `ExtractMemories` now calls `CallClaude` with `maxTokens: 4096` instead of the default 512
- **`TelegramBotService`** — added `ExtractDefaultChatMemoriesAsync` public wrapper, `ExtractMemoriesAsync` made public, `IBackgroundJobClient` injected
- **`JobService`** — `ExtractDefaultChatMemoriesAsync` registered once (outside DEBUG/RELEASE blocks) with `Cron.Never`

## Test plan

- [ ] Trigger `ExtractDefaultChatMemoriesAsync` from the Hangfire dashboard — should appear under Recurring Jobs with a Trigger Now button
- [ ] Check the resulting `BotMemories` record — summary should be more complete and untruncated

https://claude.ai/code/session_01B9zfGxUD8vDXkUr9fNnstP