### PR TITLE
Add Cycling support to Strava and Withings

### DIFF
--- a/FitWifFrens.Playground/UpdateService.cs
+++ b/FitWifFrens.Playground/UpdateService.cs
@@ -161,7 +161,7 @@ namespace FitWifFrens.Playground
             return Task.CompletedTask;
         }
 
-        private Task UpdateCycling(CancellationToken cancellationToken)
+        private async Task UpdateCycling(CancellationToken cancellationToken)
         {
             _dataContext.Metrics.AddRange(new List<Metric>
             {
@@ -199,6 +199,25 @@ namespace FitWifFrens.Playground
                 },
             });
 
+            foreach (var providerName in new[] { "Strava", "Withings" })
+            {
+                var userIds = await _dataContext.Users
+                    .Where(u => u.Logins.Any(l => l.LoginProvider == providerName))
+                    .Where(u => !u.MetricProviders.Any(ump => ump.MetricName == "Cycling" && ump.ProviderName == providerName))
+                    .Select(u => u.Id)
+                    .ToListAsync(cancellationToken);
+
+                foreach (var userId in userIds)
+                {
+                    _dataContext.UserMetricProviders.Add(new UserMetricProvider
+                    {
+                        UserId = userId,
+                        MetricName = "Cycling",
+                        ProviderName = providerName,
+                    });
+                }
+            }
+
             _dataContext.Commitments.Add(new Commitment
             {
                 Id = Guid.Parse("9f528253-67ee-443e-99fb-0b776faaa66f"),
@@ -227,8 +246,6 @@ namespace FitWifFrens.Playground
                 },
                 Periods = new List<CommitmentPeriod>()
             });
-
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Handle Strava `Ride`/`VirtualRide` and Withings categories `6` (Bicycling) + `308` (Indoor Cycling) as `Cycling` minutes, mirroring the existing `Running` pattern.
- Register the `Cycling` Metric, Strava/Withings MetricProviders, and Count/Minutes MetricValues in `RecreateService` and `UpdateService`.
- Split `UpdateService` into per-update methods (`UpdateBalances`, `UpdateTelegram`, `UpdateCycling`) so each one-off update can be run independently; only `UpdateCycling` is invoked.
- Backfill `UserMetricProvider` rows for every user already connected to Strava or Withings so existing accounts don't see "Requires Cycling" on the new commitment.
- Seed a new cycling commitment ("120 minutes" / 3 rides / 7 days) with a new `cycling0.png` image.

## Test plan
- [ ] Run `FitWifFrens.Playground` against a dev DB and confirm the Cycling Metric / MetricProviders / MetricValues / UserMetricProviders are inserted without FK errors.
- [ ] Trigger `StravaService.UpdateProviderMetricValues` for a user with recent Strava rides and confirm `UserMetricProviderValue` rows with `MetricName = "Cycling"` are created.
- [ ] Trigger `WithingsService.UpdateProviderMetricValues` for a user with recent bike workouts (category 6 or 308) and confirm Cycling rows are written.
- [ ] Open the Cycling commitment in the UI as an already-connected Strava user and confirm it no longer shows "Requires Cycling".
- [ ] Update `ContractAddress` on the new commitment to a real deployed contract before enabling it in production.
