### PR TITLE
Pick up replied-to photo on bot @mentions

### DIFF
--- a/FitWifFrens.Web/Telegram/TelegramBotService.cs
+++ b/FitWifFrens.Web/Telegram/TelegramBotService.cs
@@ -658,9 +658,18 @@ namespace FitWifFrens.Web.Telegram
 
             if (IsBotMentioned(message, _notificationServiceConfiguration.BotUsername))
             {
-                var images = hasPhoto
-                    ? await DownloadPhotoAttachmentsAsync(message, cancellationToken)
-                    : Array.Empty<(byte[] Data, string MediaType)>();
+                // Use the current message's photo if any, otherwise fall back to the photo of
+                // the message being replied to. This lets users tag the bot in a normal text
+                // reply (where bot autocomplete works) instead of a photo caption.
+                IReadOnlyList<(byte[] Data, string MediaType)> images = Array.Empty<(byte[] Data, string MediaType)>();
+                if (hasPhoto)
+                {
+                    images = await DownloadPhotoAttachmentsAsync(message, cancellationToken);
+                }
+                else if (message.TryGetProperty("reply_to_message", out var repliedTo))
+                {
+                    images = await DownloadPhotoAttachmentsAsync(repliedTo, cancellationToken);
+                }
 
                 await HandleBotMentionAsync(telegramUserId, displayName, text, chatId, messageId, images, cancellationToken);
                 return true;


### PR DESCRIPTION
## Summary
- Telegram's caption autocomplete doesn't suggest bot usernames, so @mentioning the bot in a photo caption is awkward.
- When the bot is @mentioned and the current message has no photo, also check `reply_to_message.photo` so users can send a photo first, then reply with a normal text mention (where bot autocomplete works) like `@FitWifFrensBot what's this?`.
- The original photo-caption flow continues to work unchanged.

## Test plan
- [ ] Send a photo with caption `@FitWifFrensBot describe this` → bot replies referencing the image (existing behavior, regression check).
- [ ] Send a photo with no caption, then reply to it with `@FitWifFrensBot what's this?` → bot replies referencing the replied-to image.
- [ ] @mention the bot in a plain text message (no reply, no photo) → bot replies normally without trying to fetch images.
- [ ] Reply to a non-photo message with an @mention → bot replies normally; no spurious download attempts.

https://claude.ai/code/session_01HVErCG2JXHP5eC5YztfV8h

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVErCG2JXHP5eC5YztfV8h)_