### PR TITLE
Add ambient chat messaging service for spontaneous group engagement

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -649,6 +649,59 @@ namespace FitWifFrens.Web.Background
         }
 
         /// <summary>
+        /// Given a structured snapshot of the group's current state, lets the model decide whether
+        /// there is anything worth saying right now. Returns null if the model elects to stay silent
+        /// (or if the AI client is not configured).
+        /// </summary>
+        public async Task<string?> GenerateAmbientMessage(
+            string contextSnapshot,
+            CancellationToken cancellationToken,
+            Dictionary<string, List<string>>? userFacts = null,
+            string? soulPrompt = null,
+            string? memorySummary = null)
+        {
+            try
+            {
+                var prompt =
+                    Persona("You are a witty fitness group coach hanging out in a Telegram group chat. ", soulPrompt) +
+                    "You have just been woken up and handed a snapshot of the group's current state. " +
+                    "Your job: decide whether there is something genuinely worth posting to the chat right now — " +
+                    "a milestone hit, a streak broken, a missed weigh-in worth nudging, a quiet day worth stirring up, " +
+                    "something the recent chat hinted at, or just good timing for a check-in. " +
+                    "If nothing meaningful jumps out, stay silent — do NOT manufacture a reason to post.\n\n" +
+                    "Output rules:\n" +
+                    "- If you decide to post: output ONLY the message text (max ~50 words, 1-3 short sentences). " +
+                    "No quotes, no preamble, no \"Here's a message:\". Just the message.\n" +
+                    "- If you decide not to post: output the single word SKIP and nothing else.\n" +
+                    Tone("Vary tone — sometimes hyped, sometimes teasing, sometimes warm. Never generic. ", soulPrompt) +
+                    "Reference specific people, numbers, or recent events from the snapshot to ground the message. " +
+                    "Avoid repeating something you've already said in the recent chat history.\n\n" +
+                    FormatMemoryForPrompt(memorySummary) +
+                    FormatFactsForPrompt(userFacts) +
+                    "Current snapshot:\n" + contextSnapshot;
+
+                var response = await CallClaude(prompt, cancellationToken, soulPrompt, maxTokens: 512);
+                if (string.IsNullOrWhiteSpace(response))
+                {
+                    return null;
+                }
+
+                var trimmed = response.Trim().TrimEnd('.', '!', '?').Trim();
+                if (string.Equals(trimmed, "SKIP", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                return response.Trim();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ambient message generation failed. Error: {Message}", ex.Message);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Analyzes recent chat messages and the existing memory summary to produce an updated summary document.
         /// </summary>
         public async Task<string?> ExtractMemories(

--- a/FitWifFrens.Web/Background/AmbientChatService.cs
+++ b/FitWifFrens.Web/Background/AmbientChatService.cs
@@ -1,0 +1,254 @@
+using FitWifFrens.Data;
+using Microsoft.ApplicationInsights;
+using Microsoft.EntityFrameworkCore;
+using System.Text;
+
+namespace FitWifFrens.Web.Background
+{
+    /// <summary>
+    /// Builds a snapshot of the group's current state and lets the AI decide whether to post a
+    /// spontaneous, non-event-tied message to the Telegram chat. Intended to be triggered manually
+    /// from the Hangfire dashboard while we experiment with a recurring schedule.
+    /// </summary>
+    public class AmbientChatService
+    {
+        private const int RecentChatMessageCount = 20;
+        private const int RecentWeighInDays = 7;
+        private const int RecentActivityDays = 7;
+        private const int WeightTrendDays = 28;
+
+        private readonly DataContext _dataContext;
+        private readonly NotificationService _notificationService;
+        private readonly AiSummaryService _aiSummaryService;
+        private readonly TimeProvider _timeProvider;
+        private readonly TelemetryClient _telemetryClient;
+        private readonly ILogger<AmbientChatService> _logger;
+
+        public AmbientChatService(
+            DataContext dataContext,
+            NotificationService notificationService,
+            AiSummaryService aiSummaryService,
+            TimeProvider timeProvider,
+            TelemetryClient telemetryClient,
+            ILogger<AmbientChatService> logger)
+        {
+            _dataContext = dataContext;
+            _notificationService = notificationService;
+            _aiSummaryService = aiSummaryService;
+            _timeProvider = timeProvider;
+            _telemetryClient = telemetryClient;
+            _logger = logger;
+        }
+
+        public async Task SendAmbientMessage(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var chatId = _notificationService.ChatId;
+                var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+                var nowLocal = nowUtc.ConvertTimeFromUtc();
+
+                var snapshot = await BuildSnapshot(chatId, nowUtc, nowLocal, cancellationToken);
+
+                var userFacts = await LoadUserFacts(cancellationToken);
+                var soulPrompt = await AiSummaryService.LoadSoulPromptAsync(_dataContext, chatId, cancellationToken);
+                var memorySummary = await AiSummaryService.LoadMemorySummaryAsync(_dataContext, chatId, cancellationToken);
+
+                var message = await _aiSummaryService.GenerateAmbientMessage(
+                    snapshot,
+                    cancellationToken,
+                    userFacts.Count > 0 ? userFacts : null,
+                    soulPrompt,
+                    memorySummary);
+
+                if (string.IsNullOrWhiteSpace(message))
+                {
+                    _logger.LogInformation("AmbientChatService: AI elected to stay silent.");
+                    return;
+                }
+
+                _logger.LogInformation("AmbientChatService: posting ambient message ({Length} chars).", message.Length);
+                await _notificationService.Notify(message);
+            }
+            catch (Exception exception)
+            {
+                _telemetryClient.TrackException(exception);
+                _logger.LogError(exception, "Failed sending ambient chat message.");
+                throw;
+            }
+        }
+
+        private async Task<string> BuildSnapshot(string chatId, DateTime nowUtc, DateTime nowLocal, CancellationToken cancellationToken)
+        {
+            var weighInCutoff = nowUtc.AddDays(-RecentWeighInDays);
+            var activityCutoff = nowUtc.AddDays(-RecentActivityDays);
+            var weightTrendCutoff = nowUtc.AddDays(-WeightTrendDays);
+
+            var users = await _dataContext.Users
+                .AsNoTracking()
+                .Where(u => u.TelegramUserId != null && !string.IsNullOrWhiteSpace(u.Nickname))
+                .Select(u => new { u.Id, u.Nickname, u.UserName })
+                .ToListAsync(cancellationToken);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Local time: {nowLocal:dddd, yyyy-MM-dd HH:mm} ({Constants.LocalTimeZoneId})");
+            sb.AppendLine($"UTC time:   {nowUtc:yyyy-MM-dd HH:mm}");
+            sb.AppendLine();
+
+            // Active commitment periods (current window)
+            var today = DateOnly.FromDateTime(nowLocal);
+            var activePeriods = await _dataContext.CommitmentPeriods
+                .AsNoTracking()
+                .Where(p => p.Status == CommitmentPeriodStatus.Current && p.StartDate <= today && p.EndDate >= today)
+                .Select(p => new
+                {
+                    p.Commitment.Title,
+                    p.StartDate,
+                    p.EndDate,
+                    UserCount = p.Users.Count,
+                    TotalStake = p.Users.Sum(u => u.Stake)
+                })
+                .ToListAsync(cancellationToken);
+
+            sb.AppendLine("Active commitments:");
+            if (activePeriods.Count == 0)
+            {
+                sb.AppendLine("- (none)");
+            }
+            else
+            {
+                foreach (var p in activePeriods)
+                {
+                    var daysLeft = p.EndDate.DayNumber - today.DayNumber;
+                    sb.AppendLine($"- \"{p.Title}\" — period {p.StartDate:yyyy-MM-dd} → {p.EndDate:yyyy-MM-dd} ({daysLeft} day(s) left), {p.UserCount} participant(s), total stake {p.TotalStake:0.####}");
+                }
+            }
+            sb.AppendLine();
+
+            // Per-user fitness state
+            sb.AppendLine("Members:");
+            if (users.Count == 0)
+            {
+                sb.AppendLine("- (no Telegram-linked users)");
+            }
+            else
+            {
+                foreach (var user in users)
+                {
+                    var name = !string.IsNullOrWhiteSpace(user.Nickname) ? user.Nickname! : user.UserName ?? user.Id;
+
+                    var lastWeighIn = await _dataContext.UserMetricProviderValues
+                        .AsNoTracking()
+                        .Where(v => v.UserId == user.Id && v.MetricName == "Weight" && v.MetricType == MetricType.Value)
+                        .OrderByDescending(v => v.Time)
+                        .Select(v => new { v.Time, v.Value })
+                        .FirstOrDefaultAsync(cancellationToken);
+
+                    var trendWeights = await _dataContext.UserMetricProviderValues
+                        .AsNoTracking()
+                        .Where(v => v.UserId == user.Id && v.MetricName == "Weight" && v.MetricType == MetricType.Value && v.Time >= weightTrendCutoff)
+                        .OrderBy(v => v.Time)
+                        .Select(v => v.Value)
+                        .ToListAsync(cancellationToken);
+
+                    var exerciseMinutes = await _dataContext.UserMetricProviderValues
+                        .AsNoTracking()
+                        .Where(v => v.UserId == user.Id && v.MetricName == "Exercise" && v.MetricType == MetricType.Minutes && v.Time >= activityCutoff)
+                        .SumAsync(v => v.Value, cancellationToken);
+
+                    var runningMinutes = await _dataContext.UserMetricProviderValues
+                        .AsNoTracking()
+                        .Where(v => v.UserId == user.Id && v.MetricName == "Running" && v.MetricType == MetricType.Minutes && v.Time >= activityCutoff)
+                        .SumAsync(v => v.Value, cancellationToken);
+
+                    var workoutMinutes = await _dataContext.UserMetricProviderValues
+                        .AsNoTracking()
+                        .Where(v => v.UserId == user.Id && v.MetricName == "Workout" && v.MetricType == MetricType.Minutes && v.Time >= activityCutoff)
+                        .SumAsync(v => v.Value, cancellationToken);
+
+                    var recentPolls = await _dataContext.UserTelegramPollResponses
+                        .AsNoTracking()
+                        .Where(r => r.UserId == user.Id && r.CommitmentPoll != null && r.AnsweredTime >= weighInCutoff)
+                        .Select(r => r.Value)
+                        .ToListAsync(cancellationToken);
+
+                    sb.Append("- ").Append(name).Append(": ");
+
+                    if (lastWeighIn != null)
+                    {
+                        var daysSince = (int)Math.Floor((nowUtc - lastWeighIn.Time).TotalDays);
+                        sb.Append($"weight {lastWeighIn.Value:F1}kg ({daysSince}d ago)");
+
+                        if (trendWeights.Count >= 2)
+                        {
+                            var trend = trendWeights[^1] - trendWeights[0];
+                            var trendText = trend < 0 ? $"{Math.Abs(trend):F1}kg lost"
+                                            : trend > 0 ? $"{trend:F1}kg gained"
+                                            : "no change";
+                            sb.Append($", {trendText} over {WeightTrendDays}d");
+                        }
+                    }
+                    else
+                    {
+                        sb.Append("no weigh-ins on record");
+                    }
+
+                    sb.Append($"; activity {RecentActivityDays}d: ex {exerciseMinutes:F0}m / run {runningMinutes:F0}m / workout {workoutMinutes:F0}m");
+
+                    if (recentPolls.Count > 0)
+                    {
+                        sb.Append($"; diet polls last {RecentWeighInDays}d: avg {recentPolls.Average():F1}/5 ({recentPolls.Count} response(s))");
+                    }
+                    else
+                    {
+                        sb.Append("; no recent poll responses");
+                    }
+
+                    sb.AppendLine();
+                }
+            }
+            sb.AppendLine();
+
+            // Recent chat messages so the AI can "read the room"
+            var recentMessages = await _dataContext.ChatMessages
+                .AsNoTracking()
+                .Where(m => m.ChatId == chatId)
+                .OrderByDescending(m => m.Timestamp)
+                .Take(RecentChatMessageCount)
+                .OrderBy(m => m.Timestamp)
+                .Select(m => new { m.DisplayName, m.Text, m.Timestamp })
+                .ToListAsync(cancellationToken);
+
+            sb.AppendLine($"Recent chat messages (last {recentMessages.Count}):");
+            if (recentMessages.Count == 0)
+            {
+                sb.AppendLine("- (chat is quiet)");
+            }
+            else
+            {
+                foreach (var m in recentMessages)
+                {
+                    var local = m.Timestamp.ConvertTimeFromUtc();
+                    var who = m.DisplayName == "Bot" ? "[You earlier]" : m.DisplayName;
+                    var text = m.Text.Length > 200 ? m.Text[..200] + "…" : m.Text;
+                    sb.AppendLine($"- [{local:MM-dd HH:mm}] {who}: {text}");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private async Task<Dictionary<string, List<string>>> LoadUserFacts(CancellationToken cancellationToken)
+        {
+            var rows = await _dataContext.UserFacts
+                .AsNoTracking()
+                .Where(f => f.UserId != null && f.User!.TelegramUserId != null)
+                .Select(f => new { Name = f.User!.Nickname ?? f.User.UserName ?? f.UserId!, f.Fact })
+                .ToListAsync(cancellationToken);
+
+            return rows
+                .GroupBy(r => r.Name)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.Fact).ToList());
+        }
+    }
+}

--- a/FitWifFrens.Web/Background/JobService.cs
+++ b/FitWifFrens.Web/Background/JobService.cs
@@ -96,7 +96,12 @@ namespace FitWifFrens.Web.Background
                 {
                     TimeZone = TimeZoneInfo.Utc
                 });
-            
+
+            _recurringJobManager.AddOrUpdate<AmbientChatService>(
+                nameof(AmbientChatService) + nameof(AmbientChatService.SendAmbientMessage),
+                s => s.SendAmbientMessage(cancellationToken),
+                Cron.Never);
+
             _backgroundJobClient.Enqueue<TelegramBotService>(s => s.RegisterBotCommandsAsync(CancellationToken.None));
 
             return Task.CompletedTask;

--- a/FitWifFrens.Web/Program.cs
+++ b/FitWifFrens.Web/Program.cs
@@ -181,6 +181,7 @@ namespace FitWifFrens.Web
             builder.Services.AddScoped<TelegramCorrelationSummaryService>();
             builder.Services.AddScoped<WeighInReminderService>();
             builder.Services.AddScoped<CommitmentPeriodService>();
+            builder.Services.AddScoped<AmbientChatService>();
 
             builder.Services.AddScoped<IMetamaskInterop, MetamaskBlazorInterop>();
             builder.Services.AddScoped<MetamaskHostProvider>();


### PR DESCRIPTION
## Summary
Introduces `AmbientChatService`, a new background job that periodically analyzes the group's current fitness state and uses Claude AI to decide whether to post spontaneous, contextual messages to the Telegram chat. This enables the bot to engage the group proactively based on real-time metrics, activity, and conversation context rather than only responding to scheduled events.

## Key Changes

- **New `AmbientChatService` class** (`Background/AmbientChatService.cs`):
  - Builds a structured snapshot of group state including active commitments, per-user fitness metrics (weight trends, exercise/running/workout minutes, poll responses), and recent chat history
  - Queries weight data, activity metrics, poll responses, and chat messages to provide rich context
  - Delegates message generation to `AiSummaryService.GenerateAmbientMessage()`
  - Handles errors gracefully with telemetry tracking

- **New `GenerateAmbientMessage()` method** in `AiSummaryService`:
  - Accepts a context snapshot and optional user facts, soul prompt, and memory summary
  - Instructs Claude to evaluate whether posting is meaningful (milestones, streaks, nudges, quiet periods, recent chat hints)
  - Returns the message text if the AI decides to post, or `null` if it elects to stay silent (outputs "SKIP")
  - Enforces output constraints (max ~50 words, no preamble) and encourages grounding in specific people/numbers/events

- **Job registration** in `JobService.cs`:
  - Registers `AmbientChatService.SendAmbientMessage()` as a recurring Hangfire job
  - Initially set to `Cron.Never` (manual trigger only) while experimenting with schedule

## Implementation Details

- The snapshot builder queries multiple data sources: active commitment periods, user weight/activity metrics (7-28 day windows), poll responses, and recent chat messages (last 20)
- Formats all data into a human-readable text snapshot for the AI to analyze
- Reuses existing infrastructure: `NotificationService` for posting, `AiSummaryService` for Claude calls, `TimeProvider` for timezone-aware timestamps
- Gracefully handles missing data (no weigh-ins, quiet chat, no active commitments) with fallback text
- AI prompt emphasizes specificity and avoids generic or repetitive messages

https://claude.ai/code/session_01NxLeDQHkVAX6mEyH2rqChh