### PR TITLE
Run AmbientChatService every 3 hours in production

### DIFF
--- a/FitWifFrens.Web/Background/JobService.cs
+++ b/FitWifFrens.Web/Background/JobService.cs
@@ -32,6 +32,8 @@ namespace FitWifFrens.Web.Background
             _recurringJobManager.AddOrUpdate<CommitmentPeriodService>(nameof(CommitmentPeriodService) + nameof(CommitmentPeriodService.UpdateCommitmentPeriods), s => s.UpdateCommitmentPeriods(cancellationToken), Cron.Never);
             
             _recurringJobManager.AddOrUpdate<TelegramBotService>(nameof(TelegramBotService) + nameof(TelegramBotService.ExtractAllChatMemoriesAsync), s => s.ExtractAllChatMemoriesAsync(cancellationToken), Cron.Never);
+
+            _recurringJobManager.AddOrUpdate<AmbientChatService>(nameof(AmbientChatService) + nameof(AmbientChatService.SendAmbientMessage), s => s.SendAmbientMessage(cancellationToken), Cron.Never);
 #else
             _recurringJobManager.AddOrUpdate<StravaService>(nameof(StravaService) + nameof(StravaService.UpdateWebhook), s => s.UpdateWebhook(cancellationToken), Cron.Never);
             _recurringJobManager.AddOrUpdate<WithingsService>(nameof(WithingsService) + nameof(WithingsService.UpdateWebhooks), s => s.UpdateWebhooks(cancellationToken), Cron.Never);
@@ -50,6 +52,8 @@ namespace FitWifFrens.Web.Background
             {
                 TimeZone = TimeZoneInfo.Utc
             });
+
+            _recurringJobManager.AddOrUpdate<AmbientChatService>(nameof(AmbientChatService) + nameof(AmbientChatService.SendAmbientMessage), s => s.SendAmbientMessage(cancellationToken), Cron.HourInterval(3));
 #endif
             
             _recurringJobManager.AddOrUpdate<TelegramPollJobService>(
@@ -96,11 +100,6 @@ namespace FitWifFrens.Web.Background
                 {
                     TimeZone = TimeZoneInfo.Utc
                 });
-
-            _recurringJobManager.AddOrUpdate<AmbientChatService>(
-                nameof(AmbientChatService) + nameof(AmbientChatService.SendAmbientMessage),
-                s => s.SendAmbientMessage(cancellationToken),
-                Cron.Never);
 
             _backgroundJobClient.Enqueue<TelegramBotService>(s => s.RegisterBotCommandsAsync(CancellationToken.None));
 


### PR DESCRIPTION
## Summary
- Move the `AmbientChatService` Hangfire registration into the existing `#if DEBUG / #else` conditional in `JobService.cs`
- DEBUG keeps `Cron.Never` (manual trigger from the dashboard)
- Release uses `Cron.HourInterval(3)` so the AI gets a fresh snapshot every 3 hours and posts only when it has something worth saying

## Test plan
- [ ] Build succeeds
- [ ] In production, the `AmbientChatServiceSendAmbientMessage` job appears in Hangfire with a 3-hour schedule
- [ ] Job fires on schedule; AI either posts to the Telegram chat or logs "AI elected to stay silent."
- [ ] In DEBUG, the job still shows up but only runs when manually triggered

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxLeDQHkVAX6mEyH2rqChh)_