### PR TITLE
Enable web search in Claude AI summaries and upgrade SDK

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -426,7 +426,7 @@ namespace FitWifFrens.Web.Background
                     FormatFactsForPrompt(allUserFacts) +
                     $"Output only your reply, nothing else.";
 
-                return await CallClaude(prompt, cancellationToken, soulPrompt, maxTokens: 512, images: images);
+                return await CallClaude(prompt, cancellationToken, soulPrompt, maxTokens: 512, images: images, enableWebSearch: true);
             }
             catch (Exception ex)
             {
@@ -846,11 +846,11 @@ namespace FitWifFrens.Web.Background
             return sb.ToString();
         }
 
-        private async Task<string?> CallClaude(string prompt, CancellationToken cancellationToken, string? soulPrompt = null, int maxTokens = 512, IReadOnlyList<(byte[] Data, string MediaType)>? images = null)
+        private async Task<string?> CallClaude(string prompt, CancellationToken cancellationToken, string? soulPrompt = null, int maxTokens = 512, IReadOnlyList<(byte[] Data, string MediaType)>? images = null, bool enableWebSearch = false)
         {
             if (_client == null) return null;
 
-            _logger.LogInformation("AiSummaryService: calling Claude API. Images={ImageCount}", images?.Count ?? 0);
+            _logger.LogInformation("AiSummaryService: calling Claude API. Images={ImageCount}, WebSearch={WebSearch}", images?.Count ?? 0, enableWebSearch);
 
             Message userMessage;
             if (images != null && images.Count > 0)
@@ -885,16 +885,34 @@ namespace FitWifFrens.Web.Background
                 SystemMessage = soulPrompt,
             };
 
+            if (enableWebSearch)
+            {
+                // Offer the web search tool — Claude decides per-message whether to use it.
+                // Legacy version keeps it to plain web search (no code-execution sandbox).
+                parameters.Tools = new List<Common.Tool>
+                {
+                    Common.ServerTools.GetWebSearchTool(maxUses: 3, toolVersion: Common.ServerTools.WebSearchVersionLegacy)
+                };
+            }
+
             var response = await _client.Messages.GetClaudeMessageAsync(parameters);
 
             _logger.LogInformation("AiSummaryService: Claude API responded. StopReason={StopReason}, ContentCount={Count}",
                 response.StopReason, response.Content?.Count ?? 0);
 
-            var text = response.Content?.OfType<TextContent>().FirstOrDefault()?.Text?.Trim();
+            // A web search turn can return multiple text blocks interleaved with tool/result
+            // blocks — join them so the full reply is captured, not just the first fragment.
+            var text = response.Content == null
+                ? null
+                : string.Join("\n\n", response.Content
+                    .OfType<TextContent>()
+                    .Select(t => t.Text?.Trim())
+                    .Where(t => !string.IsNullOrWhiteSpace(t)));
 
             if (string.IsNullOrWhiteSpace(text))
             {
                 _logger.LogWarning("AiSummaryService: response contained no text content.");
+                return null;
             }
 
             return text;

--- a/FitWifFrens.Web/FitWifFrens.Web.csproj
+++ b/FitWifFrens.Web/FitWifFrens.Web.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Nethereum.Metamask.Blazor" Version="4.20.*" />
     <PackageReference Include="Nethereum.UI" Version="4.20.*" />
     <PackageReference Include="Nethereum.Web3" Version="4.20.*" />
-    <PackageReference Include="Anthropic.SDK" Version="3.*" />
+    <PackageReference Include="Anthropic.SDK" Version="5.*" />
     <PackageReference Include="Polly" Version="8.4.*" />
     <PackageReference Include="ScottPlot" Version="5.1.*" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.*" />


### PR DESCRIPTION
## Summary
Upgrades the Anthropic SDK to v5 and enables web search capability for Claude API calls in the AI summary service. This allows Claude to search the web when generating fitness summaries, providing more contextual and up-to-date information.

## Key Changes

- **Upgraded Anthropic.SDK** from v3 to v5 to access web search tool functionality
- **Added `enableWebSearch` parameter** to `CallClaude()` method (defaults to `false` for backward compatibility)
- **Enabled web search for fitness summaries** by passing `enableWebSearch: true` when generating AI summaries
- **Configured web search tool** with legacy version and max 3 uses per request to control API costs
- **Improved text extraction** from Claude responses to handle multiple text blocks returned when web search is used (joins all text content blocks instead of taking only the first)
- **Enhanced logging** to include web search status in API call logs
- **Added null check** for empty responses to prevent returning whitespace-only strings

## Implementation Details

The web search tool is conditionally added to the Claude API request parameters only when `enableWebSearch` is true. Claude decides per-message whether to actually invoke the tool based on the prompt context.

The response parsing was updated to join all `TextContent` blocks with newlines, since web search responses can interleave text with tool/result blocks. This ensures the full reply is captured rather than just the first text fragment.

https://claude.ai/code/session_01AL32PDmnZXpHpkK6YqSkCm