### PR TITLE
Add SessionStart hook to install .NET 8 for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) sessions — local machines have their own SDK.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Install the .NET 8 SDK from the Ubuntu archive if it isn't already present.
+# Idempotent: container state is cached after the hook completes, so later sessions
+# skip the install. NOTE: the .NET binary CDN (builds.dotnet.microsoft.com / aka.ms)
+# is blocked by the network policy, so dotnet-install.sh does not work here — but the
+# Ubuntu archive ships dotnet-sdk-8.0 and is reachable.
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "Installing .NET 8 SDK via apt ..."
+  export DEBIAN_FRONTEND=noninteractive
+  # Tolerate blocked third-party PPAs (deadsnakes/ondrej) — the Ubuntu archive,
+  # which is what we need, updates fine.
+  apt-get update || true
+  apt-get install -y dotnet-sdk-8.0
+fi
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export DOTNET_CLI_TELEMETRY_OPTOUT=1"
+    echo "export DOTNET_NOLOGO=1"
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+# Warm up NuGet restore so the first build in the session is fast (api.nuget.org is
+# reachable). Non-fatal: a transient feed hiccup shouldn't block the session start.
+dotnet restore "$PROJECT_DIR/FitWifFrens.sln" \
+  || echo "warning: 'dotnet restore' did not complete; the first build will restore on demand."
+
+echo ".NET ready: $(dotnet --version)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a `SessionStart` hook so Claude Code on the web sessions can build the solution.

**Why:** web containers don't ship the .NET SDK, and the .NET binary CDN (`builds.dotnet.microsoft.com` / `aka.ms`) is blocked by the network policy, so `dotnet-install.sh` doesn't work. The Ubuntu archive (reachable) ships `dotnet-sdk-8.0`, so the hook installs from there, then warms the NuGet cache via `dotnet restore`.

**Scope:** two new files only — `.claude/hooks/session-start.sh` and `.claude/settings.json`. No application code is touched (master's existing `AiSummaryService.cs`/csproj build fix is left intact).

**Behavior:** web-only (gated on `CLAUDE_CODE_REMOTE`), idempotent (skips install once `dotnet` is present), and non-fatal on a transient restore hiccup. Validated by running the hook (install skips when SDK present, restore succeeds, exit 0) and a clean `dotnet build` of the solution.

https://claude.ai/code/session_01AL32PDmnZXpHpkK6YqSkCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL32PDmnZXpHpkK6YqSkCm)_