### PR TITLE
Add generic exercise notification for non-specific activities

### DIFF
--- a/FitWifFrens.Web/Background/AiSummaryService.cs
+++ b/FitWifFrens.Web/Background/AiSummaryService.cs
@@ -255,6 +255,58 @@ namespace FitWifFrens.Web.Background
         }
 
         /// <summary>
+        /// Generates a short, fun message for a real-time, generic exercise notification — any
+        /// physical activity that isn't already posted via a more specific path (e.g. a workout).
+        /// Pass <paramref name="activityType"/> when a meaningful type is known (e.g. a Strava
+        /// "Swim"/"Walk"), or null for a generic "exercise" message. Falls back to a simple
+        /// default message if the AI call fails.
+        /// </summary>
+        public async Task<string> GenerateExerciseMessage(
+            string name,
+            string? activityType,
+            double minutes,
+            CancellationToken cancellationToken,
+            Dictionary<string, List<string>>? userFacts = null,
+            string? soulPrompt = null,
+            string? memorySummary = null)
+        {
+            var hasType = !string.IsNullOrWhiteSpace(activityType) &&
+                          !string.Equals(activityType, "Exercise", StringComparison.OrdinalIgnoreCase);
+
+            var header = hasType
+                ? $"{name} just logged a {activityType} ({minutes:F0} min)"
+                : $"{name} just logged {minutes:F0} min of exercise";
+
+            try
+            {
+                var activityDescription = hasType
+                    ? $"{name} just logged a {activityType} for {minutes:F0} minutes. "
+                    : $"{name} just logged {minutes:F0} minutes of exercise. ";
+
+                var prompt =
+                    Persona("You are a witty fitness group coach posting a real-time exercise update to a group chat. ", soulPrompt) +
+                    activityDescription +
+                    $"Write a single short message (max 20 words) reacting to this exercise. " +
+                    Tone("Be fun and encouraging. Vary the style each time. Keep it friendly. ", soulPrompt) +
+                    FormatMemoryForPrompt(memorySummary) +
+                    FormatFactsForPrompt(userFacts) +
+                    $"Output only the message, no quotes, no extra text.";
+
+                var aiMessage = await CallClaude(prompt, cancellationToken, soulPrompt);
+                if (aiMessage != null)
+                {
+                    return $"{header}\n{aiMessage}";
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AI exercise message generation failed, using default. Error: {Message}", ex.Message);
+            }
+
+            return header;
+        }
+
+        /// <summary>
         /// Generates a fun reminder for a user who hasn't weighed in for a while.
         /// Falls back to a default reminder if the AI call fails.
         /// </summary>

--- a/FitWifFrens.Web/Background/StravaService.cs
+++ b/FitWifFrens.Web/Background/StravaService.cs
@@ -192,6 +192,10 @@ namespace FitWifFrens.Web.Background
 
                     var activityType = activityJson.GetProperty("type").GetString();
 
+                    // Tracks whether this activity has already been announced to the chat (e.g. via the
+                    // workout path) so the generic "Exercise" catch-all below doesn't double-post it.
+                    var sentToChat = false;
+
                     if (activityType == "Run" || activityType == "VirtualRun")
                     {
                         var userMetricProviderValue = await _dataContext.UserMetricProviderValues
@@ -275,6 +279,8 @@ namespace FitWifFrens.Web.Background
                                     user.Nickname!, activityType!, activityMinutes, cancellationToken, userFacts, soulPrompt, memorySummary);
 
                                 _ = _notificationService.Notify(message);
+
+                                sentToChat = true;
                             }
 
                             _dataContext.UserMetricProviderValues.Add(new UserMetricProviderValue
@@ -306,6 +312,29 @@ namespace FitWifFrens.Web.Background
 
                         if (userMetricProviderValue == null)
                         {
+                            // Anything not already announced (runs, rides, swims, walks, hikes, ...) gets
+                            // pushed to the chat as a generic exercise log.
+                            if (!sentToChat && !string.IsNullOrWhiteSpace(user.Nickname))
+                            {
+                                var factsRaw = await _dataContext.UserFacts
+                                    .AsNoTracking()
+                                    .Where(f => f.UserId == user.Id)
+                                    .Select(f => f.Fact)
+                                    .ToListAsync(cancellationToken);
+                                var userFacts = factsRaw.Count > 0
+                                    ? new Dictionary<string, List<string>> { { user.Nickname!, factsRaw } }
+                                    : null;
+
+                                var soulPrompt = await AiSummaryService.LoadSoulPromptAsync(_dataContext, _notificationService.ChatId, cancellationToken);
+                                var memorySummary = await AiSummaryService.LoadMemorySummaryAsync(_dataContext, _notificationService.ChatId, cancellationToken);
+                                var message = await _aiSummaryService.GenerateExerciseMessage(
+                                    user.Nickname!, activityType, activityMinutes, cancellationToken, userFacts, soulPrompt, memorySummary);
+
+                                _ = _notificationService.Notify(message);
+
+                                sentToChat = true;
+                            }
+
                             _dataContext.UserMetricProviderValues.Add(new UserMetricProviderValue
                             {
                                 UserId = user.Id,

--- a/FitWifFrens.Web/Background/WithingsService.cs
+++ b/FitWifFrens.Web/Background/WithingsService.cs
@@ -393,6 +393,10 @@ namespace FitWifFrens.Web.Background
 
                         var activityCategory = activityJson.GetProperty("category").GetInt32();
 
+                        // Tracks whether this activity has already been announced to the chat (e.g. via the
+                        // workout path) so the generic "Exercise" catch-all below doesn't double-post it.
+                        var sentToChat = false;
+
                         // https://github.com/zono-dev/withings-go/blob/514b8ec90158faa88e36508f778fbf7c2b03e209/withings/enum.go#L125
                         // https://help.validic.com/space/VCS/1681326286/Withings+API+Integration+for+Developers
                         if (activityCategory == 6 || activityCategory == 308)
@@ -449,6 +453,8 @@ namespace FitWifFrens.Web.Background
                                         user.Nickname!, "Workout", activityMinutes, cancellationToken, userFacts, soulPrompt);
 
                                     _ = _notificationService.Notify(message);
+
+                                    sentToChat = true;
                                 }
 
                                 _dataContext.UserMetricProviderValues.Add(new UserMetricProviderValue
@@ -480,6 +486,28 @@ namespace FitWifFrens.Web.Background
 
                             if (userMetricProviderValue == null)
                             {
+                                // Anything not already announced (walks, runs, swims, ...) gets pushed to
+                                // the chat as a generic exercise log.
+                                if (!sentToChat && !string.IsNullOrWhiteSpace(user.Nickname))
+                                {
+                                    var factsRaw = await _dataContext.UserFacts
+                                        .AsNoTracking()
+                                        .Where(f => f.UserId == user.Id)
+                                        .Select(f => f.Fact)
+                                        .ToListAsync(cancellationToken);
+                                    var userFacts = factsRaw.Count > 0
+                                        ? new Dictionary<string, List<string>> { { user.Nickname!, factsRaw } }
+                                        : null;
+
+                                    var soulPrompt = await AiSummaryService.LoadSoulPromptAsync(_dataContext, _notificationService.ChatId, cancellationToken);
+                                    var message = await _aiSummaryService.GenerateExerciseMessage(
+                                        user.Nickname!, null, activityMinutes, cancellationToken, userFacts, soulPrompt);
+
+                                    _ = _notificationService.Notify(message);
+
+                                    sentToChat = true;
+                                }
+
                                 _dataContext.UserMetricProviderValues.Add(new UserMetricProviderValue
                                 {
                                     UserId = user.Id,


### PR DESCRIPTION
## Summary
Adds support for posting generic exercise notifications to the group chat for fitness activities that don't fit into specific workout categories (e.g., Strava "Walk", Withings generic exercises). Previously, only runs, rides, swims, and hikes were announced; other activities were silently logged without chat notification.

## Key Changes

- **New method `GenerateExerciseMessage()` in `AiSummaryService`**: Generates short, fun AI-powered messages for generic exercise activities. Accepts optional `activityType` for typed activities (e.g., "Walk") or null for generic "exercise" messages. Falls back to a simple default if AI generation fails.

- **Updated `StravaService.UpdateProviderMetricValues()`**: 
  - Added `sentToChat` flag to track whether an activity has already been announced via a specific path (e.g., workout)
  - Implemented catch-all logic for unannounced activities: calls `GenerateExerciseMessage()` with the activity type and posts to chat before logging the metric

- **Updated `WithingsService.UpdateProviderMetricValues()`**:
  - Added `sentToChat` flag to prevent double-posting
  - Implemented catch-all logic for unannounced activities: calls `GenerateExerciseMessage()` with null activity type (generic "exercise" message) and posts to chat

## Implementation Details

- The `sentToChat` flag prevents duplicate notifications when an activity matches multiple category checks
- Both services load user facts, soul prompt, and memory summary before calling `GenerateExerciseMessage()` to maintain consistent AI personalization
- The new method respects the existing AI fallback pattern: if Claude call fails, returns a simple header message without AI enhancement
- Withings integration omits `memorySummary` parameter (not loaded in that service), while Strava includes it for richer context

https://claude.ai/code/session_01GC3zxYdt7DkYqNSkWXLqGh