### PR TITLE
Fix metric provider filtering in external logins management

### DIFF
--- a/FitWifFrens.Web/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/FitWifFrens.Web/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -308,11 +308,20 @@
     {
         var userId = await UserManager.GetUserIdAsync(user);
 
-        foreach (var metric in metrics)   
+        foreach (var metric in metrics)
         {
+            var updateMetricProvider = UpdateMetricProviders!.MetricProviders!.SingleOrDefault(mp => mp.MetricName == metric.Name);
+
+            // Skip metrics that were not part of the submitted form (e.g. "Telegram Poll"),
+            // otherwise their UserMetricProvider would be incorrectly deleted.
+            if (updateMetricProvider == null)
+            {
+                continue;
+            }
+
             var userMetricProvider = userMetricProviders.SingleOrDefault(ump => ump.MetricName == metric.Name);
 
-            var updateMetricProviderName = UpdateMetricProviders!.MetricProviders!.SingleOrDefault(mp => mp.MetricName == metric.Name)?.ProviderName;
+            var updateMetricProviderName = updateMetricProvider.ProviderName;
 
             if (userMetricProvider != null)
             {


### PR DESCRIPTION
## Summary
Fixed a bug in the external logins management page where metrics not submitted in the form (e.g., "Telegram Poll") were being incorrectly processed, potentially causing their `UserMetricProvider` records to be deleted.

## Changes
- Added a null check to skip metrics that don't have a corresponding entry in the submitted form data
- Refactored the metric provider lookup to avoid redundant LINQ queries and improve code clarity
- Added explanatory comment documenting why certain metrics must be skipped during processing

## Implementation Details
The fix extracts the `UpdateMetricProvider` lookup into a variable at the start of the loop iteration. If the lookup returns null (indicating the metric was not part of the submitted form), the iteration is skipped with `continue`. This prevents downstream logic from attempting to process metrics that shouldn't be updated, which was causing unintended deletions of user metric provider associations.

This is particularly important for metrics like "Telegram Poll" that may be displayed but not included in form submission, ensuring their data integrity is preserved during the update operation.

https://claude.ai/code/session_012ap33pjK8Gqjujx3j9CqyE